### PR TITLE
Enable TLSv1.2 on Database Connection

### DIFF
--- a/1-ecs-monolith-stack/ecs_monolith/ecs_monolith_stack.py
+++ b/1-ecs-monolith-stack/ecs_monolith/ecs_monolith_stack.py
@@ -71,7 +71,7 @@ class EcsMonolithStack(core.Stack):
                 'SPRING_DATASOURCE_PASSWORD': 'Welcome#123456',
                 'SPRING_DATASOURCE_USERNAME': 'master',
                 'SPRING_PROFILES_ACTIVE': 'mysql',
-                'SPRING_DATASOURCE_URL': 'jdbc:mysql://' + rdsInst.db_instance_endpoint_address + '/petclinic?useUnicode=true'
+                'SPRING_DATASOURCE_URL': 'jdbc:mysql://' + rdsInst.db_instance_endpoint_address + '/petclinic?useUnicode=true&enabledTLSProtocols=TLSv1.2'
               }
             }
         )


### PR DESCRIPTION
*Issue #, if available:*

Due to recent updates, connections using < TLSv1.2 causes a connection failure when attempting to communicate with the MySQL database:

javax.net.ssl.SSLHandshakeException: No appropriate protocol (protocol is disabled or cipher suites are inappropriat

*Description of changes:*

TLSv1.2 is not enabled by default, but this change explicitly enables TLSv1.2 via a parameter in the connection string.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
